### PR TITLE
Change accessibility label

### DIFF
--- a/SimpleWindowSwitcher/sws_WindowSwitcher.c
+++ b/SimpleWindowSwitcher/sws_WindowSwitcher.c
@@ -130,7 +130,7 @@ static void _sws_WindowSwitcher_UpdateAccessibleText(sws_WindowSwitcher* _this)
             swprintf_s(
                 wszAccText,
                 MAX_PATH * 2,
-                L"%s: %d out of %d",
+                L"%s: %d of %d",
                 wszTitle,
                 _this->layout.pWindowList.cbSize - _this->layout.iIndex,
                 _this->layout.pWindowList.cbSize


### PR DESCRIPTION
Change accessibility label to say index like 1 of 5 rather than 1 out of 5 to match behavior of screen readers.